### PR TITLE
Skip deploy during remote compatibility dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,7 +883,7 @@ jobs:
           if-no-files-found: error
 
   deploy-web-prod:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.compat_remote_dry_run)
     runs-on: namespace-profile-linux-medium
     timeout-minutes: 30
     concurrency:

--- a/docs/browser-compat-completion-audit.md
+++ b/docs/browser-compat-completion-audit.md
@@ -126,13 +126,13 @@ Current repository/environment audit:
   `WEB_URL=https://app.biovault.net/web/ WEB_COMPAT_CHECK_WEB_URL_REACHABLE=1 WEB_COMPAT_REQUIRE_REMOTE_ANDROID=1 WEB_COMPAT_REQUIRE_REMOTE_IOS=1 WEB_COMPAT_INCLUDE_DEFERRED=1 npm run check:browser-compat-infra`,
   accepts the provider-reachable `WEB_URL` and still reports the missing
   Android/iOS endpoints.
-- The pushed `madhava/browser-testing` branch passes
-  `WEB_COMPAT_PROVIDER_REF=madhava/browser-testing npm run check:browser-compat-provider-workflow`,
-  so CI provider runs can be dispatched from that ref once endpoint JSON is
-  available. The live `main` GitHub Actions workflow still exposes only the
-  legacy `deploy_ref` manual input and must be updated before `COMPAT_REF=main`
-  provider runs can use `compat_web_url`, `compat_include_ios`,
-  `compat_remote_targets`, or `compat_completion`.
+- The live `main` GitHub Actions workflow passes
+  `WEB_COMPAT_PROVIDER_REF=main npm run check:browser-compat-provider-workflow`,
+  so CI provider runs can be dispatched from `main` once endpoint JSON is
+  available. A safe `compat_remote_dry_run=true` workflow dispatch on `main`
+  reached `Check remote browser provider secret` and failed there with an empty
+  `BROWSER_COMPAT_REMOTE_ENDPOINTS_JSON`, confirming that the endpoint secret
+  is not currently visible to the workflow.
 - Remote matrix dry-runs pass for both the default Android target set and the
   full Android+iOS target set using
   `tests/browser-compat-remote-endpoints.example.json`, which verifies target

--- a/docs/browser-compat-provider-runs.md
+++ b/docs/browser-compat-provider-runs.md
@@ -482,7 +482,8 @@ Manual CI inputs:
   remote compatibility run and requires those result rows during validation.
 - `compat_remote_dry_run=true` validates endpoint secret visibility, target
   selection, and provider-reachable `WEB_URL` without fetching fixtures,
-  opening provider browser sessions, or producing compatibility evidence.
+  opening provider browser sessions, deploying the web app, or producing
+  compatibility evidence.
 - `compat_completion=true` downloads `web-compat*-artifacts`, merges them,
   refreshes `lib/browser-support.generated.ts` and `TODO.md`, checks
   browser-compat docs/script references, runs the strict completion audit, and


### PR DESCRIPTION
## Summary

- Prevent `deploy-web-prod` from running when manual CI is dispatched with `compat_remote_dry_run=true`.
- Update the provider runbook to state that dry runs do not deploy the web app.
- Update the completion audit with the observed dry-run result: `BROWSER_COMPAT_REMOTE_ENDPOINTS_JSON` is currently empty in CI.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- `npm run check:browser-compat-docs`
- `npm run test:browser-compat-docs`
- `git diff --check`
- `npm run test:browser-compat-static`

## Notes

This does not complete the Android/iOS provider TODO rows; it only makes the safe provider preflight path avoid a production deploy.
