### PR TITLE
Check provider runbook CI dispatch commands

### DIFF
--- a/scripts/check-browser-compat-docs.mjs
+++ b/scripts/check-browser-compat-docs.mjs
@@ -64,6 +64,7 @@ for (const file of files) {
 		errors.push(...remoteTargetListErrors(text, file, 'The current required provider targets are:'))
 		errors.push(...endpointInputErrors(text, file))
 		errors.push(...resultContractErrors(text, file))
+		errors.push(...providerDispatchCommandErrors(text, file))
 	}
 	errors.push(...workflowDispatchPrerequisiteErrors(text, file))
 	errors.push(...publicWebUrlErrors(text, file, path.basename(absolute)))
@@ -158,6 +159,20 @@ function workflowDispatchPrerequisiteErrors(text, file) {
 	return mentionsPushedRef && mentionsMergedRef ? [] : [
 		`${file} provider CI dispatch instructions must mention that workflow inputs need a pushed branch or merged main ref`,
 	]
+}
+
+function providerDispatchCommandErrors(text, file) {
+	const requiredTokens = [
+		['compat_remote_dry_run=true', 'safe remote provider dry-run dispatch'],
+		['compat_local_smoke=true', 'local smoke evidence dispatch'],
+		['compat_versions=true', 'historical browser evidence dispatch'],
+		['compat_android_local=true', 'Android-local evidence dispatch'],
+		['compat_include_ios=true', 'iOS provider evidence dispatch'],
+		['compat_completion=true', 'strict completion dispatch'],
+	]
+	return requiredTokens.flatMap(([token, label]) => (
+		text.includes(token) ? [] : [`${file} is missing ${label}: ${token}`]
+	))
 }
 
 function publicWebUrlErrors(text, file, basename) {

--- a/scripts/check-browser-compat-docs.test.mjs
+++ b/scripts/check-browser-compat-docs.test.mjs
@@ -133,6 +133,9 @@ test('accepts provider runbook target list that matches the completion contract'
 			'Each target must run the same WASM demo/report happy path.',
 			...endpointInputLines(),
 			...resultContractLines(),
+			'Use a pushed feature branch while validating, or `main` after the workflow changes are merged.',
+			'Run `gh workflow run CI -f compat_web_url=https://app.biovault.net/web/ -f compat_remote_dry_run=true` first.',
+			'Then run `gh workflow run CI -f compat_local_smoke=true -f compat_versions=true -f compat_android_local=true -f compat_include_ios=true -f compat_completion=true`.',
 			'',
 		].join('\n'),
 		completionContract: completionContractFixture(),
@@ -258,6 +261,61 @@ test('accepts provider CI dispatch docs that mention pushed branch and merged ma
 			'Use a pushed feature branch while validating, or `main` after the workflow changes are merged.',
 			'',
 		].join('\n'),
+	})
+
+	const result = runChecker(fixture)
+	assert.equal(result.status, 0, result.stderr || result.stdout)
+})
+
+test('rejects provider runbook that omits the full evidence dispatch inputs', () => {
+	const fixture = createFixture({
+		scripts: {},
+		doc: '',
+		providerDoc: [
+			'# Browser Compatibility Provider Runs',
+			'',
+			'The current required provider targets are:',
+			'',
+			...targetList(),
+			'',
+			'Each target must run the same WASM demo/report happy path.',
+			...endpointInputLines(),
+			...resultContractLines(),
+			'',
+			'Use a pushed feature branch while validating, or `main` after the workflow changes are merged.',
+			'Run `gh workflow run CI -f compat_web_url=https://app.biovault.net/web/ -f compat_remote_dry_run=true`.',
+			'',
+		].join('\n'),
+		completionContract: completionContractFixture(),
+	})
+
+	const result = runChecker(fixture)
+	assert.equal(result.status, 1)
+	assert.match(result.stderr, /missing local smoke evidence dispatch: compat_local_smoke=true/)
+	assert.match(result.stderr, /missing strict completion dispatch: compat_completion=true/)
+})
+
+test('accepts provider runbook with dry-run and full evidence dispatch inputs', () => {
+	const fixture = createFixture({
+		scripts: {},
+		doc: '',
+		providerDoc: [
+			'# Browser Compatibility Provider Runs',
+			'',
+			'The current required provider targets are:',
+			'',
+			...targetList(),
+			'',
+			'Each target must run the same WASM demo/report happy path.',
+			...endpointInputLines(),
+			...resultContractLines(),
+			'',
+			'Use a pushed feature branch while validating, or `main` after the workflow changes are merged.',
+			'Run `gh workflow run CI -f compat_web_url=https://app.biovault.net/web/ -f compat_remote_dry_run=true` first.',
+			'Then run `gh workflow run CI -f compat_local_smoke=true -f compat_versions=true -f compat_android_local=true -f compat_include_ios=true -f compat_completion=true`.',
+			'',
+		].join('\n'),
+		completionContract: completionContractFixture(),
 	})
 
 	const result = runChecker(fixture)


### PR DESCRIPTION
## Summary
- add docs-check coverage for the provider runbook's safe dry-run dispatch command
- require the real evidence command to keep local smoke, historical, Android-local, iOS, and completion inputs documented

## Verification
- npm run test:browser-compat-docs
- npm run check:browser-compat-docs
- git diff --check