### PR TITLE
Document LambdaTest endpoint render placeholders

### DIFF
--- a/docs/browser-compat-provider-runs.md
+++ b/docs/browser-compat-provider-runs.md
@@ -221,6 +221,17 @@ npm run --silent render:browser-compat-endpoints -- browserstack tests/browser-c
 	> browser-compat-endpoints.json
 ```
 
+For LambdaTest, the checked-in template uses `LT_USERNAME` and
+`LT_ACCESS_KEY` instead:
+
+```sh
+GITHUB_SHA="$(git rev-parse HEAD)" \
+LT_USERNAME=... \
+LT_ACCESS_KEY=... \
+npm run --silent render:browser-compat-endpoints -- lambdatest tests/browser-compat-provider-capabilities.example.json \
+	> browser-compat-endpoints.json
+```
+
 The common generated filenames `browser-compat-endpoints*.json`,
 `browserstack-caps*.json`, `lambdatest-caps*.json`, `sauce-caps*.json`,
 `*-browser-compat-caps*.json`, and `*-browser-compat-endpoints*.json` are

--- a/scripts/check-browser-compat-docs.mjs
+++ b/scripts/check-browser-compat-docs.mjs
@@ -49,6 +49,8 @@ const providerRenderTokens = [
 	['GITHUB_SHA', 'provider build label placeholder'],
 	['BROWSERSTACK_USERNAME', 'BrowserStack username placeholder'],
 	['BROWSERSTACK_ACCESS_KEY', 'BrowserStack access key placeholder'],
+	['LT_USERNAME', 'LambdaTest username placeholder'],
+	['LT_ACCESS_KEY', 'LambdaTest access key placeholder'],
 ]
 
 for (const file of files) {

--- a/scripts/check-browser-compat-docs.test.mjs
+++ b/scripts/check-browser-compat-docs.test.mjs
@@ -662,6 +662,8 @@ function providerRenderLines() {
 		'Render endpoints with GITHUB_SHA="$(git rev-parse HEAD)" and',
 		'BROWSERSTACK_USERNAME/BROWSERSTACK_ACCESS_KEY before running',
 		'npm run --silent render:browser-compat-endpoints -- browserstack tests/browser-compat-provider-capabilities.example.json.',
+		'For LambdaTest, set LT_USERNAME and LT_ACCESS_KEY before running',
+		'npm run --silent render:browser-compat-endpoints -- lambdatest tests/browser-compat-provider-capabilities.example.json.',
 	]
 }
 


### PR DESCRIPTION
## Summary

- add the LambdaTest endpoint-render command to the provider runbook
- require LambdaTest credential placeholders in the browser compatibility docs drift guard
- include LambdaTest render details in docs guard fixtures

## Verification

- npm run check:browser-compat-docs
- npm run test:browser-compat-docs
- GITHUB_SHA=$(git rev-parse --short HEAD) LT_USERNAME=dummy LT_ACCESS_KEY=dummy npm run --silent render:browser-compat-endpoints -- lambdatest tests/browser-compat-provider-capabilities.example.json

## Completion status

This improves the provider handoff path. It does not complete TODO.md; real Android/iOS remote-provider endpoints and evidence are still required for the eight mobile targets tracked in #66.